### PR TITLE
add tsconfig from each app

### DIFF
--- a/packages/first-app/tsconfig.json
+++ b/packages/first-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src"
+  },
+  "include": ["src/*"]
+}

--- a/packages/second-app/tsconfig.json
+++ b/packages/second-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src"
+  },
+  "include": ["src/*"]
+}


### PR DESCRIPTION
If you add a `tsconfig.json` for each package/app, Typescript will only reference the `styled.d.ts` from it's `srcDir` and not the other packages